### PR TITLE
(maint) Fix for PowerShell Core and Git tags 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # PowerShell based Ruby Installer
 
 PowerShell Module to help installing Ruby on Windows
+
+## Building the module
+
+Requires the `ModuleBuilder` module
+
+``` powershell
+PS> Install-Module -Name ModuleBuilder -scope CurrentUser
+```

--- a/RubyInstaller/Private/Get-FirstGitHubRef.ps1
+++ b/RubyInstaller/Private/Get-FirstGitHubRef.ps1
@@ -1,0 +1,15 @@
+Function Get-FirstGitHubRef($Owner, $Repo, $Refs) {
+  $Found = $False
+  ForEach($Ref in $Refs) {
+    Try {
+      Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/git/ref/tags/$Ref" | Out-Null
+      Write-Output $Ref
+      $Found = $True
+      break
+    } Catch {
+      # Ignore the Error
+    }
+  }
+
+  if (-Not $Found) { Throw "Could not find any suitable tags in GitHub Repo $Owner-$Repo for $($Refs -join ', ')"}
+}

--- a/RubyInstaller/Public/Install-Ruby.ps1
+++ b/RubyInstaller/Public/Install-Ruby.ps1
@@ -20,10 +20,10 @@ Function Install-Ruby {
     # Remember and fiddle with the allowed protocols for web requests
     $CurrentProtocol = [System.Net.ServicePointManager]::SecurityProtocol
     # Workaround for https://github.com/majkinetor/au/issues/142
-    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor
-      768 -bor
-      [System.Net.SecurityProtocolType]::Tls -bor
-      [System.Net.SecurityProtocolType]::Ssl3
+    [System.Net.ServicePointManager]::SecurityProtocol = `
+      [System.Net.SecurityProtocolType]::Tls11 -bor
+      [System.Net.SecurityProtocolType]::Tls12 -bor
+      [System.Net.SecurityProtocolType]::Tls
 
     try {
       # Preflight checks...
@@ -34,9 +34,9 @@ Function Install-Ruby {
       # Opinionated Ruby List (mainly for Puppet Developers)
       # TODO: Update for 2.5, 2.4 and 2.6? Drop 2.1?
       $rubyList = @(
-        '2.1.9', '2.1.9 (x64)',
         '2.4.4-2 (x86)', '2.4.4-2 (x64)',
-        '2.5.1-2 (x86)', '2.5.1-2 (x64)'
+        '2.5.1-2 (x86)', '2.5.1-2 (x64)',
+        '2.7.2-1 (x86)', '2.7.2-1 (x64)'
       )
       $ChocolateyTools = Get-ChocolateyTools
       $devKit2_64 = Join-Path -Path $ChocolateyTools -ChildPath 'DevKit2-x64'
@@ -103,9 +103,10 @@ Function Install-Ruby {
             # 32bit 'https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-2.5.1-1/rubyinstaller-2.5.1-1-x86.7z'
             # 64bit 'https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-2.5.1-1/rubyinstaller-2.5.1-1-x64.7z'
             if ($rubyIs64) {
-              $rubyURL = "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-${rubyVersion}/rubyinstaller-${rubyVersion}-x64.7z"
+              $Ref = Get-FirstGitHubRef -Owner 'oneclick' -Repo 'rubyinstaller2' -Refs "rubyinstaller-${rubyVersion}","RubyInstaller-${rubyVersion}"
+              $rubyURL = "https://github.com/oneclick/rubyinstaller2/releases/download/$Ref/rubyinstaller-${rubyVersion}-x64.7z"
             } else {
-              $rubyURL = "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-${rubyVersion}/rubyinstaller-${rubyVersion}-x86.7z"
+              $rubyURL = "https://github.com/oneclick/rubyinstaller2/releases/download/$Ref/rubyinstaller-${rubyVersion}-x86.7z"
             }
             $RIDKDevKit = $true
           }


### PR DESCRIPTION
* Uses enumerations for TLS security protocols to avoid hardcoding
* Removes the use of SSL3 as it's not really appropriate and it was causing
  SSL/TLS issues
* Uses a lookup system to find matching Github tags as the oneclick installer
  project changes the case of the tag
* Removes Ruby 2.1.9 it's really really not supported